### PR TITLE
Refactor some object- and array-type attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "block-test",
-	"version": "0.1.0",
+	"version": "0.1.2",
 	"description": "Example static block scaffolded with Create Block tool.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/plugin.php
+++ b/plugin.php
@@ -495,15 +495,15 @@ function utkwds_register_patterns() {
 		<!-- /wp:paragraph -->
 		
 		<!-- wp:group {\"className\":\"my-5\"} -->
-		<div class=\"wp-block-group my-5\"><!-- wp:utkwds/button {\"buttonColor\":{\"name\":\"Link\",\"slug\":\"btn-link\",\"color\":\"\",\"text\":\"\"},\"buttonText\":true} -->
+		<div class=\"wp-block-group my-5\"><!-- wp:utkwds/button {\"color\":\"\",\"colorSlug\":\"btn-link\",\"buttonText\":true} -->
 		<div><a class=\"btn save mb-3 btn-link btn-nrml\"><span>Explore Area 01</span><span></span></a></div>
 		<!-- /wp:utkwds/button -->
 		
-		<!-- wp:utkwds/button {\"buttonColor\":{\"name\":\"Link\",\"slug\":\"btn-link\",\"color\":\"\",\"text\":\"\"},\"buttonText\":true} -->
+		<!-- wp:utkwds/button {\"color\":\"\",\"colorSlug\":\"btn-link\",\"buttonText\":true} -->
 		<div><a class=\"btn save mb-3 btn-link btn-nrml\"><span>Explore Area 02</span><span></span></a></div>
 		<!-- /wp:utkwds/button -->
 		
-		<!-- wp:utkwds/button {\"buttonColor\":{\"name\":\"Link\",\"slug\":\"btn-link\",\"color\":\"\",\"text\":\"\"},\"buttonText\":true} -->
+		<!-- wp:utkwds/button {\"color\":\"\",\"colorSlug\":\"btn-link\",\"buttonText\":true} -->
 		<div><a class=\"btn save mb-3 btn-link btn-nrml\"><span>Explore Area 03</span><span></span></a></div>
 		<!-- /wp:utkwds/button --></div>
 		<!-- /wp:group --></div>
@@ -544,7 +544,7 @@ function utkwds_register_patterns() {
 		<p>Aliquam erat volutpat. Morbi et dictum elit, sed sagittis urna. Nam quis tempor justo, quis tempor augue. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Quisque elit tortor, aliquam sed nisi ac, semper laoreet nulla. Nullam in finibus urna. Sed gravida sapien dapibus tortor facilisis pretium. Aenean accumsan arcu a enim semper, quis porta ligula tincidunt. In hac habitasse platea dictumst. Cras tempor velit eget massa convallis, bibendum aliquam felis cursus.</p>
 		<!-- /wp:paragraph -->
 		
-		<!-- wp:utkwds/button {\"buttonColor\":{\"name\":\"Link\",\"slug\":\"btn-link\",\"color\":\"\",\"text\":\"\"},\"buttonText\":true} -->
+		<!-- wp:utkwds/button {\"color\":\"\",\"colorSlug\":\"btn-link\",\"buttonText\":true} -->
 		<div><a class=\"btn save mb-3 btn-link btn-nrml\"><span>Explore Vulputate</span><span></span></a></div>
 		<!-- /wp:utkwds/button --></div>
 		<!-- /wp:utkwds/column -->

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description:       utkwds is a Gutenberg plugin created via Create Block tool.
  * Requires at least: 5.8
  * Requires PHP:      7.0
- * Version:           0.1.0
+ * Version:           0.1.2
  * Author:            University of Tennessee, Office of Communications and Marketing
  * Author URI:		  https://communications.utk.edu/
  * License:           GPL2+

--- a/src/blocks/alert/block.json
+++ b/src/blocks/alert/block.json
@@ -11,9 +11,13 @@
 		"html": false
 	},
 	"attributes": {
-		"imagePostion": {
-			"type": "object",
-			"default": { "name": "Smokey", "slug": "alert-smokey", "color": "#58595B", "text": "text-white"}
+		"colorSlug": {
+			"type": "string",
+			"default": "alert-smokey"
+		},
+		"color": {
+			"type": "string",
+			"default": "#58595B"
 		},
 		"text": {
 			"type": "string",

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -46,6 +46,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									colorSlug: thisColor.slug.replace("bg-", "alert-"),

--- a/src/blocks/alert/edit.js
+++ b/src/blocks/alert/edit.js
@@ -34,7 +34,7 @@ import './editor.scss';
  */
 export default function Edit( props ) {
 	const { attributes, setAttributes, clientId } = props;
-	const { imagePostion } = attributes;
+	const { colorSlug, color } = attributes;
 
 	const blockProps = useBlockProps();
 
@@ -44,11 +44,13 @@ export default function Edit( props ) {
 				<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.imagePostion.color }
+							value={ color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("bg-", "alert-");
-								setAttributes( { imagePostion:thisColor } );
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								setAttributes({
+									colorSlug: thisColor.slug.replace("bg-", "alert-"),
+									color: thisColor.color,
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -58,7 +60,7 @@ export default function Edit( props ) {
 				</PanelBody>
 			</InspectorControls>,
 			<div { ...blockProps }>
-		  	<div className={ 'alert ' + imagePostion.slug }>
+		  	<div className={ 'alert ' + colorSlug }>
 				<RichText
 					tagName='span'
 					key={ clientId }

--- a/src/blocks/alert/save.js
+++ b/src/blocks/alert/save.js
@@ -24,10 +24,10 @@ import { RichText } from '@wordpress/block-editor';
  */
 export default function save( props ) {
 	const { attributes } = props;
-	const { imagePostion } = attributes;
+	const { colorSlug } = attributes;
 
 	return (
-		<div className={ 'alert ' + imagePostion.slug + " " + attributes.className }>
+		<div className={ 'alert ' + colorSlug + " " + attributes.className }>
 				<RichText.Content
 					tagName="span"
 					value={ attributes.text }

--- a/src/blocks/button/block.json
+++ b/src/blocks/button/block.json
@@ -48,9 +48,13 @@
 			"type": "string",
 			"default": "Button"
 		},
-		"buttonColor": {
-			"type": "object",
-			"default": { "name": "Link", "slug": "btn-utlink", "color": "#1a73c5", "text": "text-white" }
+		"color": {
+			"type": "string",
+			"default": "#1a73c5"
+		},
+		"colorSlug": {
+			"type": "string",
+			"default": "btn-utlink"
 		},
 		"buttonText": {
 			"type": "boolean",
@@ -68,9 +72,13 @@
 			"type": "string",
 			"default": ""
 		},
-		"iconCode": {
-			"type": "object",
-			"default": { "name": "", "string": "", "code": null }
+		"iconName": {
+			"type": "string",
+			"default": ""
+		},
+		"iconString": {
+			"type": "string",
+			"default": ""
 		},
 		"iconSize": {
 			"type": "string",

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -103,13 +103,9 @@ export default function Edit( props ) {
 
 	//console.log(siteColors);
 
-	function onButtonColorChange( newColor ) {
-		setAttributes( { buttonColor: newColor } );
-	}
-
-	if(attributes.iconCode.name !== ''){
+	if(attributes.iconName !== ''){
 		var iconResults = AllIcons.find(obj => {
-			return obj.name === attributes.iconCode.name;
+			return obj.name === attributes.iconName;
 		} );
 
 		attributes.useIcon = false;
@@ -176,49 +172,77 @@ export default function Edit( props ) {
                 					title: 'No Icon',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-app" viewBox="0 0 16 16"><path d="M11 2a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V5a3 3 0 0 1 3-3h6zM5 1a4 4 0 0 0-4 4v6a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4V5a4 4 0 0 0-4-4H5z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'', string:'', code:null }, useIcon:true } );
+										setAttributes({
+											iconName: '',
+											iconString: '',
+											useIcon:true
+										});
 									},
             					},
 								{
                 					title: 'Box arrow up-right',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Box arrow up-right', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Box arrow up-right',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z"/><path fill-rule="evenodd" d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z"/></svg>`,
+											useIcon: true
+										});
 									},
             					},
 								{
                 					title: 'Check 2',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Check 2', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Check 2',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg>`,
+											useIcon:true
+										});
 									},
             					},
 								{
                 					title: 'Check 2 circle',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-circle" viewBox="0 0 16 16"><path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0z"/><path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l7-7z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Check 2 circle', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-circle" viewBox="0 0 16 16"><path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0z"/><path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l7-7z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-circle" viewBox="0 0 16 16"><path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0z"/><path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l7-7z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Check 2 circle',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check2-circle" viewBox="0 0 16 16"><path d="M2.5 8a5.5 5.5 0 0 1 8.25-4.764.5.5 0 0 0 .5-.866A6.5 6.5 0 1 0 14.5 8a.5.5 0 0 0-1 0 5.5 5.5 0 1 1-11 0z"/><path d="M15.354 3.354a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0l7-7z"/></svg>`,
+											useIcon:true
+										});
 									},
             					},
 								{
                 					title: 'Chevron right',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Chevron right', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Chevron right',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/></svg>`,
+											useIcon:true
+										});
 									},
             					},
 								{
                 					title: 'Chevron left',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Chevron left', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Chevron left',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/></svg>`,
+											useIcon: true
+										});
 									},
             					},
 								{
                 					title: 'Plus',
                 					icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>,
 				  					onClick: () =>{
-										setAttributes( { iconCode:{ name:'Plus', string:'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>', code:(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>) }, useIcon:true } );
+										setAttributes({
+											iconName: 'Plus',
+											iconString: /* html */ `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16"><path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/></svg>`,
+											useIcon:true
+										});
 									},
             					},
 							] }
@@ -236,12 +260,13 @@ export default function Edit( props ) {
 					<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.buttonColor.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("bg-", "btn-");
-								thisColor.slug = thisColor.slug.replace("btn-outline-", "btn-");
-								setAttributes( { buttonColor:thisColor } );
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: thisColor.slug.replace("bg-", "btn-").replace("btn-outline-", "btn-")
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -258,15 +283,17 @@ export default function Edit( props ) {
 					<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.buttonColor.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("bg-", "btn-outline-");
-								if(thisColor.slug.indexOf("outline-") === -1){
-									thisColor.slug = thisColor.slug.replace("btn-", "btn-outline-");
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								let newColorSlug = thisColor.slug.replace("bg-", "btn-outline-");
+								if (newColorSlug.indexOf("outline-") === -1){
+									newColorSlug = newColorSlug.replace("btn-", "btn-outline-");
 								}
-								//var thisTextColor = getColorObjectByColorValue( textColors, value );
-								setAttributes( { buttonColor:thisColor } );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: newColorSlug
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -285,26 +312,25 @@ export default function Edit( props ) {
 								//console.log(attributes.buttonOutline);
 
 								if( !attributes.buttonOutline === true ){
-									//const thisColor = getColorObjectByColorValue( outlineColors, attributes.buttonColor.color );
-
-									var thisColor = getColorObjectByColorValue( siteColors, attributes.buttonColor.color );
-									thisColor.slug = thisColor.slug.replace("bg-", "btn-outline-");
-									if(thisColor.slug.indexOf("outline-") === -1){
-										thisColor.slug = thisColor.slug.replace("btn-", "btn-outline-");
+									const thisColor = getColorObjectByColorValue( siteColors, attributes.color );
+									let newColorSlug = thisColor.slug.replace("bg-", "btn-outline-");
+									if (newColorSlug.indexOf("outline-") === -1) {
+										newColorSlug = newColorSlug.replace("btn-", "btn-outline-");
 									}
-									//var thisTextColor = getColorObjectByColorValue( textColors, value );
-									setAttributes( { buttonColor:thisColor } );
+									setAttributes({
+										color: thisColor.color,
+										colorSlug: newColorSlug
+									});
 									//console.log(thisColor);
 								}else{
-									//const thisColor = getColorObjectByColorValue( colors, attributes.buttonColor.color );
-									var thisColor = getColorObjectByColorValue( siteColors, attributes.buttonColor.color );
-									thisColor.slug = thisColor.slug.replace("bg-", "btn-");
-									thisColor.slug = thisColor.slug.replace("btn-outline-", "btn-");
-									setAttributes( { buttonColor:thisColor } );
+									const thisColor = getColorObjectByColorValue( siteColors, attributes.color );
+									setAttributes({
+										color: thisColor.color,
+										colorSlug: thisColor.slug.replace("bg-", "btn-").replace("btn-outline-", "btn-")
+									});
 									//console.log(thisColor);
 								}
 
-								//console.log(attributes.buttonColor);
 							} }
 						/>
 					</PanelRow>
@@ -318,13 +344,18 @@ export default function Edit( props ) {
 								setAttributes( { buttonText: !attributes.buttonText } );
 								//console.log(attributes.buttonOutline);
 
-								if( !attributes.buttonText === true ){
-									setAttributes( { buttonColor:{ name: 'Link', slug: 'btn-link', color: '', text: ''} } );
-								}else{
-									setAttributes( { buttonColor:{ name: 'Link', slug: 'btn-utlink', color: '#1a73c5', text: 'text-light'}, buttonOutline:false } );
+								if ( !attributes.buttonText === true ) {
+									setAttributes({
+										color: '',
+										colorSlug: 'btn-link'
+									});
+								} else {
+									setAttributes({
+										color: '#1a73c5',
+										colorSlug: 'btn-utlink',
+										buttonOutline: false
+									});
 								}
-
-								//console.log(attributes.buttonColor);
 							} }
 						/>
 					</PanelRow>
@@ -358,7 +389,7 @@ export default function Edit( props ) {
 			</InspectorControls>,
 			<div { ...blockProps }>
 			<div className={ attributes.blockClass } >
-				<div className={ 'btn mb-3 ' + attributes.buttonColor.slug + attributes.buttonSize }>
+				<div className={ 'btn mb-3 ' + attributes.colorSlug + attributes.buttonSize }>
 					<RichText
 						tagName='span'
 						placeholder={ attributes.placeholder }
@@ -373,7 +404,7 @@ export default function Edit( props ) {
 						size={ attributes.iconSize }
 					/>
 					) }
-					{ attributes.iconCode.code !== null && attributes.useIcon === true && (
+					{ attributes.iconString !== '' && attributes.useIcon === true && (
 					<Icon
 						icon={ iconResults.code }
 						size={ attributes.iconSize }

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -262,6 +262,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									color: thisColor.color,
@@ -285,6 +286,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								let newColorSlug = thisColor.slug.replace("bg-", "btn-outline-");
 								if (newColorSlug.indexOf("outline-") === -1){

--- a/src/blocks/button/save.js
+++ b/src/blocks/button/save.js
@@ -28,7 +28,7 @@ export default function save( props ) {
 	return (
 		<div className={ attributes.className }>
 			<a
-				className={ 'btn save mb-3 ' + attributes.buttonColor.slug + attributes.buttonSize }
+				className={ 'btn save mb-3 ' + attributes.colorSlug + attributes.buttonSize }
 				href={ attributes.url }
 				title={ attributes.title }
 				target={ attributes.linkTarget }
@@ -40,7 +40,7 @@ export default function save( props ) {
 				/>
 				<RichText.Content
 					tagName="span"
-					value={ attributes.iconCode.string }
+					value={ attributes.iconString }
 				/>
 			</a>
 			</div>

--- a/src/blocks/calendar/block.json
+++ b/src/blocks/calendar/block.json
@@ -24,31 +24,27 @@
 			"default": 31
 		},
 		"department": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"place": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"group": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"type": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"topic": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"audience": {
-			"type": "array",
-			"default": ""
-		},
-		"all_types": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"keywords": {
@@ -92,19 +88,15 @@
 			"default": ""
 		},
 		"exType": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"exTopic": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"exAudience": {
-			"type": "array",
-			"default": ""
-		},
-		"exAll_types": {
-			"type": "array",
+			"type": "string",
 			"default": ""
 		},
 		"widgetType": {

--- a/src/blocks/calendar/edit.js
+++ b/src/blocks/calendar/edit.js
@@ -28,6 +28,18 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import './editor.scss';
 
 /**
+ * The returned string is the array's string-elements, comma-separated and URI-encoded.
+ * @param {string[]} arr
+ */
+const toStr = (arr) => arr.map(str => encodeURIComponent(str)).join(',');
+
+/**
+ * Splits a string at the commas and URI-decodes the elements of the returned array.
+ * @param {string} str
+ */
+const toArr = (str) => str.split(',').map(s => decodeURIComponent(s));
+
+/**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
@@ -40,15 +52,15 @@ export default function Edit( props ) {
 
 	const blockProps = useBlockProps();
 
-	attributes.all_types = attributes.type.concat(attributes.topic, attributes.audience);
-		attributes.exAll_types = attributes.exType.concat(attributes.exTopic, attributes.exAudience);
-	
+	const all_types = [attributes.type, attributes.topic, attributes.audience].filter(Boolean).join(',');
+	const exAll_types = [attributes.exType, attributes.exTopic, attributes.exAudience].filter(Boolean).join(',');
+	// console.log({attributes, all_types, exAll_types})
 		//var urlParams = Object.entries(CalScript).map(([key, val]) => `${key}=${encodeURIComponent(val)}`).join('&');
 
-		const calScript = document.createElement( 'script' );
-		calScript.src = "https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + attributes.all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + attributes.exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template;
+		// const calScript = document.createElement( 'script' );
+		// calScript.src = "https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template;
 	
-		//console.log(calScript);
+		// console.log(calScript);
 
 		return ( [
 			<InspectorControls>
@@ -97,34 +109,49 @@ export default function Edit( props ) {
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.group }
+						value={ toArr(attributes.group) }
 						options={ all_groups }
-						onChange={ ( value ) =>{ setAttributes( {group:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ group: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Department'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.department }
+						value={ toArr(attributes.department) }
 						options={ all_departments }
-						onChange={ ( value ) =>{ setAttributes( {department:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ department: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Place'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.place }
+						value={ toArr(attributes.place) }
 						options={ all_places }
-						onChange={ ( value ) =>{ setAttributes( {place:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ place: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Event Type'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.type }
+						value={ toArr(attributes.type) }
 						options={ [
 							{ label: 'Academic & Financial Dates', value: '113455' },
 							{ label: 'Ceremonies & Special Events', value: '114205' },
@@ -139,14 +166,19 @@ export default function Edit( props ) {
 							{ label: 'Sports & Recreation', value: '113105' },
 							{ label: 'Training & Workshops', value: '114206' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {type:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ type: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Topic'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.topic }
+						value={ toArr(attributes.topic) }
 						options={ [
 							{ label: 'Academic Administration', value: '117945' },
 							{ label: 'Admissions', value: '113721' },
@@ -169,14 +201,19 @@ export default function Edit( props ) {
 							{ label: 'Visual & Performing Arts', value: '114610' },
 							{ label: 'Volunteering', value: '116008' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {topic:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ topic: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Audience'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.audience }
+						value={ toArr(attributes.audience) }
 						options={ [
 							{ label: 'Alumni', value: '113116' },
 							{ label: 'Current Students', value: '113114' },
@@ -185,7 +222,12 @@ export default function Edit( props ) {
 							{ label: 'General Public', value: '113117' },
 							{ label: 'Prospective Students', value: '113118' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {audience:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ audience: toStr(value) });
+							}
+						}
 					/>
 				    <TextControl
 						label='Keywords and Tags'
@@ -267,7 +309,7 @@ export default function Edit( props ) {
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.exType }
+						value={ toArr(attributes.exType) }
 						options={ [
 							{ label: 'Academic & Financial Dates', value: '113455' },
 							{ label: 'Ceremonies & Special Events', value: '114205' },
@@ -282,14 +324,19 @@ export default function Edit( props ) {
 							{ label: 'Sports & Recreation', value: '113105' },
 							{ label: 'Training & Workshops', value: '114206' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {exType:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ exType: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Exclude Topic'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.exTopic }
+						value={ toArr(attributes.exTopic) }
 						options={ [
 							{ label: 'Academic Administration', value: '117945' },
 							{ label: 'Admissions', value: '113721' },
@@ -312,14 +359,19 @@ export default function Edit( props ) {
 							{ label: 'Visual & Performing Arts', value: '114610' },
 							{ label: 'Volunteering', value: '116008' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {exTopic:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ exTopic: toStr(value) });
+							}
+						}
 					/>
 					<SelectControl
 						label='Exclude Audience'
 						multiple
 						help="Hold CTRL (CMD on Mac) to make multiple selections."
 						style={{height: '150px'}}
-						value={ attributes.exAudience }
+						value={ toArr(attributes.exAudience) }
 						options={ [
 							{ label: 'Alumni', value: '113116' },
 							{ label: 'Current Students', value: '113114' },
@@ -328,7 +380,12 @@ export default function Edit( props ) {
 							{ label: 'General Public', value: '113117' },
 							{ label: 'Prospective Students', value: '113118' },
 						] }
-						onChange={ ( value ) =>{ setAttributes( {exAudience:value} ); } }
+						onChange={
+							/** @param {string[]} value */
+							(value) => {
+								setAttributes({ exAudience: toStr(value) });
+							}
+						}
 					/>
 				</PanelBody>
 				<PanelBody title='Display Options' initialOpen={ false }>
@@ -504,7 +561,7 @@ export default function Edit( props ) {
 			</InspectorControls>,
 			<div { ...blockProps } >
 			<SandBox
-				html={ "<div id='localist-widget-12345' class='localist-widget'></div><script defer type='text/javascript' src='https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + attributes.all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + attributes.exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template + "'></script>" }
+				html={ "<div id='localist-widget-12345' class='localist-widget'></div><script defer type='text/javascript' src='https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template + "'></script>" }
 				type="embed"
 			/>
 			</div>,

--- a/src/blocks/calendar/save.js
+++ b/src/blocks/calendar/save.js
@@ -25,11 +25,15 @@ import { __ } from '@wordpress/i18n';
 export default function save( props ) {
 	const { attributes } = props;
 
+	const all_types = [attributes.type, attributes.topic, attributes.audience].filter(Boolean).join(',');
+	const exAll_types = [attributes.exType, attributes.exTopic, attributes.exAudience].filter(Boolean).join(',');
+
+	// console.log({attributes, all_types, exAll_types})
 	return (
 		<div className={ attributes.className }>
 			<div id="localist-widget-12345" className="localist-widget"></div>
 			<script defer type="text/javascript"
-src={"https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + attributes.all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + attributes.exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template}></script>
+src={"https://calendar.utk.edu/widget/" + attributes.widgetType + "?schools=utk&venues=" + attributes.place + "&departments=" +  attributes.department  + "&groups=" + attributes.group + "&types=" + all_types + "&days=" + attributes.daysAhead + "&num=" + attributes.numResults + "&tags=" + attributes.keywords + attributes.featuredS + attributes.sponsoredS + attributes.matchingS + attributes.pastS + attributes.hideDescS + attributes.truncateS + attributes.htmlDescS + attributes.evImageS + attributes.evTimeS + attributes.viewAllS + attributes.newWinS + attributes.hideDropS + "&match=" + attributes.mustMatch + "&exclude_types=" + exAll_types + "&container=localist-widget-12345" + attributes.incStyleS + "&template=" + attributes.template}></script>
 			</div>
 	);
 }

--- a/src/blocks/card-body/block.json
+++ b/src/blocks/card-body/block.json
@@ -8,7 +8,7 @@
 	"icon": "media-text",
 	"description": "Contains all the text elements within a Card.",
 	"parent": [ "utkwds/card-main" ],
-	"usesContext": [ "card/cardColor", "card/cardOutline" ],
+	"usesContext": [ "card/colorSlug", "card/cardOutline" ],
 	"supports": {
 		"html": false
 	},

--- a/src/blocks/card-body/edit.js
+++ b/src/blocks/card-body/edit.js
@@ -53,7 +53,7 @@ export default function Edit( props ) {
 	  const blockProps = useBlockProps();
 
 	  if( context['card/cardOutline'] === true ){
-		const thisColor = context['card/cardColor'].slug.replace('border-', 'text-');
+		const thisColor = context['card/colorSlug'].replace('border-', 'text-');
 		setAttributes( { textColor:thisColor } );
 	}
 

--- a/src/blocks/card/block.json
+++ b/src/blocks/card/block.json
@@ -15,9 +15,13 @@
 			"type": "string",
 			"default": "utkwds/card"
 		},
-		"cardColor": {
-			"type": "object",
-			"default": { "name": "Light", "slug": "bg-light", "color": "#F6F6F6", "text": "text-dark" }
+		"color": {
+			"type": "string",
+			"default": "#F6F6F6"
+		},
+		"colorSlug": {
+			"type": "string",
+			"default": "bg-light"
 		},
 		"cardOutline": {
 			"type": "boolean",
@@ -29,8 +33,8 @@
 		}
 	},
 	"providesContext": {
-    	"card/blockName": "blockName",
-		"card/cardColor": "cardColor",
+    "card/blockName": "blockName",
+		"card/colorSlug": "colorSlug",
 		"card/cardOutline": "cardOutline"
 	},
 	"textdomain": "utkwds",

--- a/src/blocks/card/edit.js
+++ b/src/blocks/card/edit.js
@@ -107,11 +107,14 @@ export default function Edit( props ) {
 					<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.cardColor.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("border-", "bg-");
-								setAttributes( { cardColor:thisColor, textColor:thisColor.text } );
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: thisColor.slug.replace("border-", "bg-"),
+									textColor:thisColor.text
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -128,11 +131,14 @@ export default function Edit( props ) {
 					<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.cardColor.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("bg-", "border-");
-								setAttributes( { cardColor:thisColor, textColor:"" } );
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: thisColor.slug.replace("bg-", "border-"),
+									textColor: ''
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -150,14 +156,20 @@ export default function Edit( props ) {
 								//console.log(attributes.buttonOutline);
 
 								if( !attributes.cardOutline === true ){
-									var thisColor = getColorObjectByColorValue( siteColors, attributes.cardColor.color );
-									thisColor.slug = thisColor.slug.replace("bg-", "border-");
-									setAttributes( { cardColor:thisColor, textColor:"" } );
+									const thisColor = getColorObjectByColorValue( siteColors, attributes.color );
+									setAttributes({
+										color: thisColor.color,
+										colorSlug: thisColor.slug.replace("bg-", "border-"),
+										textColor: ''
+									});
 									//console.log(thisColor);
 								}else{
-									var thisColor = getColorObjectByColorValue( siteColors, attributes.cardColor.color );
-									thisColor.slug = thisColor.slug.replace("border-", "bg-");
-									setAttributes( { cardColor:thisColor, textColor:thisColor.text } );
+									const thisColor = getColorObjectByColorValue( siteColors, attributes.color );
+									setAttributes({
+										color: thisColor.color,
+										colorSlug: thisColor.slug.replace("border-", "bg-"),
+										textColor:thisColor.text
+									});
 									//console.log(thisColor);
 								}
 
@@ -169,7 +181,7 @@ export default function Edit( props ) {
 			</InspectorControls>,
 			// eslint-disable-next-line react/jsx-key
 			<div { ...blockProps }>
-			<div className={'card card-edit ' + attributes.textColor + ' ' + attributes.cardColor.slug }>
+			<div className={'card card-edit ' + attributes.textColor + ' ' + attributes.colorSlug }>
 				<InnerBlocks allowedBlocks={ [ 'utkwds/card-body', 'utkwds/card-image', 'utkwds/columns', 'utkwds/card-topcap', 'card/body', 'card/image', 'utksds/columns', 'card/topcap' ] } placeholder={ cardPlaceholder } templateLock={ 'all' } renderAppender={ () => ( <InnerBlocks.ButtonBlockAppender /> ) } />
 			</div>
 			</div>,

--- a/src/blocks/card/edit.js
+++ b/src/blocks/card/edit.js
@@ -109,6 +109,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									color: thisColor.color,
@@ -133,6 +134,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									color: thisColor.color,

--- a/src/blocks/card/save.js
+++ b/src/blocks/card/save.js
@@ -26,7 +26,7 @@ export default function save( props ) {
 	const { attributes } = props;
 
 	return (
-		<div className={'card ' + attributes.textColor + ' ' + attributes.cardColor.slug + ' ' + attributes.className }>
+		<div className={'card ' + attributes.textColor + ' ' + attributes.colorSlug + ' ' + attributes.className }>
 				<InnerBlocks.Content />
 			</div>
 	);

--- a/src/blocks/media-object/edit.js
+++ b/src/blocks/media-object/edit.js
@@ -55,6 +55,7 @@ export default function Edit( props ) {
 		const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 		function onBackgroundColorChange( newColor ) {
+			if (!newColor) return;
 			setAttributes( { backgroundColor: newColor } );
 		}
 

--- a/src/blocks/overlay-main/block.json
+++ b/src/blocks/overlay-main/block.json
@@ -11,7 +11,6 @@
 		"html": false
 	},
 	"parent": [ "utkwds/overlay" ],
-	"usesContext": [ "overlay/bgColor", "overlay/opacity" ],
 	"textdomain": "utkwds",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css"

--- a/src/blocks/overlay/block.json
+++ b/src/blocks/overlay/block.json
@@ -19,10 +19,6 @@
 			"type": "string",
 			"default": ""
 		},
-		"overColor": {
-			"type": "object",
-			"default": { "name": "Dark", "slug": "bg-dark", "color": "", "text": "text-white" }
-		},
 		"color": {
 			"type": "string",
 			"default": "#4b4b4b"

--- a/src/blocks/overlay/block.json
+++ b/src/blocks/overlay/block.json
@@ -21,16 +21,24 @@
 		},
 		"overColor": {
 			"type": "object",
-			"default": { "name": "Dark", "slug": "bg-dark", "color": "#4b4b4b", "text": "text-white" }
+			"default": { "name": "Dark", "slug": "bg-dark", "color": "", "text": "text-white" }
+		},
+		"color": {
+			"type": "string",
+			"default": "#4b4b4b"
+		},
+		"colorSlug": {
+			"type": "string",
+			"default": "bg-dark"
+		},
+		"textColor": {
+			"type": "string",
+			"default": "text-white"
 		},
 		"overOpacity": {
 			"type": "integer",
 			"default": 0
 		}
-	},
-	"providesContext": {
-		"overlay/bgColor": "overColor",
-		"overlay/opacity": "overOpacity"
 	},
 	"textdomain": "utkwds",
 	"editorScript": "file:./index.js",

--- a/src/blocks/overlay/edit.js
+++ b/src/blocks/overlay/edit.js
@@ -80,10 +80,14 @@ export default function Edit( props ) {
 				<PanelRow>
 					<ColorPalette
 							colors = { siteColors }
-							value={ attributes.overColor.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
 								const thisColor = getColorObjectByColorValue( siteColors, value );
-								setAttributes( { overColor:thisColor } );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: thisColor.slug,
+									textColor: thisColor.text
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -103,7 +107,7 @@ export default function Edit( props ) {
 				</PanelBody>
 			</InspectorControls>,
 			<div { ...blockProps }>
-			<div className={ "card wpeditor-card-overlay overlay " + attributes.overColor.slug + " overlay-" + attributes.overOpacity + " " + attributes.overColor.text }>
+			<div className={ "card wpeditor-card-overlay overlay " + attributes.colorSlug + " overlay-" + attributes.overOpacity + " " + attributes.textColor }>
 				{ attributes.imageUrl !== '' && (
   				<img src={ attributes.imageUrl } className="card-img" alt={ attributes.imageAlt } />
 				) }

--- a/src/blocks/overlay/edit.js
+++ b/src/blocks/overlay/edit.js
@@ -82,6 +82,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									color: thisColor.color,

--- a/src/blocks/overlay/save.js
+++ b/src/blocks/overlay/save.js
@@ -26,7 +26,7 @@ export default function save( props ) {
 	const { attributes } = props;
 
 	return (
-		<div className={ "card overlay " + attributes.overColor.slug + " overlay-" + attributes.overOpacity + " " + attributes.overColor.text + " " + attributes.className }>
+		<div className={ "card overlay " + attributes.colorSlug + " overlay-" + attributes.overOpacity + " " + attributes.textColor + " " + attributes.className }>
 				<img
 					src={ attributes.imageUrl }
 					className={ 'card-img' }

--- a/src/blocks/strip/block.json
+++ b/src/blocks/strip/block.json
@@ -11,9 +11,17 @@
 		"html": false
 	},
 	"attributes": {
-		"imagePostion": {
-			"type": "object",
-			"default": { "name": "Smokey", "slug": "strip-smokey", "color": "#58595B", "text": "text-white" }
+		"color": {
+			"type": "string",
+			"default": "#58595B"
+		},
+		"colorSlug": {
+			"type": "string",
+			"default": "strip-smokey"
+		},
+		"textColor": {
+			"type": "string",
+			"default": "text-white"
 		},
 		"spacing": {
 			"type": "integer",
@@ -23,8 +31,9 @@
 			"type": "string",
 			"default": "py-0"
 		},
-		"bgImage":{
-			"type": "object"
+		"imageUrl": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"textdomain": "utkwds",

--- a/src/blocks/strip/edit.js
+++ b/src/blocks/strip/edit.js
@@ -68,6 +68,7 @@ export default function Edit( props ) {
 							colors = { siteColors }
 							value={ attributes.color }
 							onChange={ ( value ) =>{
+								if (!value) return;
 								const thisColor = getColorObjectByColorValue( siteColors, value );
 								setAttributes({
 									color: thisColor.color,

--- a/src/blocks/strip/edit.js
+++ b/src/blocks/strip/edit.js
@@ -1,5 +1,6 @@
 import { Button, ResponsiveWrapper, PanelBody, PanelRow, RangeControl, RadioControl } from '@wordpress/components';
 import { siteColors } from '../../globals.js'
+import { useState } from '@wordpress/element'
 
 /**
  * Retrieves the translation of text.
@@ -40,13 +41,14 @@ export default function Edit( props ) {
     	setAttributes
 	  } = props;
 
-	  const { imagePostion } = attributes;
-
 	  const blockProps = useBlockProps();
 
+		const [image, setImage] = useState(undefined);
+
 		const onRemoveImage = () => {
-            setAttributes( { bgImage: undefined, } );
-        };
+			setAttributes({ imageUrl: '' });
+			setImage(undefined);
+		};
 
 		return ( [
 			<InspectorControls>
@@ -60,15 +62,18 @@ export default function Edit( props ) {
 						max={ 5 }
 				/>
 				</PanelRow>
-				{ attributes.bgImage === undefined &&
+				{ image === undefined &&
 				<PanelRow>
 						<ColorPalette
 							colors = { siteColors }
-							value={ attributes.imagePostion.color }
+							value={ attributes.color }
 							onChange={ ( value ) =>{
-								var thisColor = getColorObjectByColorValue( siteColors, value );
-								thisColor.slug = thisColor.slug.replace("bg-", "strip-");
-								setAttributes( { imagePostion:thisColor } );
+								const thisColor = getColorObjectByColorValue( siteColors, value );
+								setAttributes({
+									color: thisColor.color,
+									colorSlug: thisColor.slug.replace("bg-", "strip-"),
+									textColor: thisColor.text
+								});
 								//console.log(thisColor);
 							} }
 							disableCustomColors={ true }
@@ -80,23 +85,23 @@ export default function Edit( props ) {
 				<MediaUploadCheck>
 					<MediaUpload
 						onSelect={ ( media ) =>{
-							setAttributes( {bgImage: media} );
-
-							console.log(media);
+							setAttributes({ imageUrl: media.url });
+							setImage(media);
+							// console.log(media);
 						} }
 						allowedTypes={ [ 'image' ] }
-						value={ attributes.bgImage }
+						value={ image }
 						render={ ( { open } ) => (
 							<Button
-								className={ ! attributes.bgImage ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' }
+								className={ ! image ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' }
 								onClick={ open }>
-								{ attributes.bgImage === undefined && ( 'Select a Background Image' ) }
-								{ attributes.bgImage && (
+								{ image === undefined && ( 'Select a Background Image' ) }
+								{ image && (
 									<ResponsiveWrapper
-                                    	naturalWidth={ attributes.bgImage.width }
-                                        naturalHeight={ attributes.bgImage.height }
+                                    	naturalWidth={ image.width }
+                                        naturalHeight={ image.height }
                                     >
-										<img src={ attributes.bgImage.url } alt={ attributes.bgImage.alt } style={ { "maxHeight":attributes.bgImage.height, "maxWidth":attributes.bgImage.width } } />
+										<img src={ image.url } alt={ image.alt } style={ { "maxHeight":image.height, "maxWidth":image.width } } />
                                     </ResponsiveWrapper>
 								) }
 							</Button>
@@ -104,15 +109,16 @@ export default function Edit( props ) {
 					/>
 				</MediaUploadCheck>
 				</PanelRow>
-				{ attributes.bgImage &&
+				{ image &&
 				<PanelRow>
                 <MediaUploadCheck>
                 	<MediaUpload
                     	onSelect={ ( media ) =>{
-							setAttributes( {bgImage: media} );
+												setAttributes({ imageUrl: media.url });
+												setImage(media)
 						} }
                         allowedTypes={ [ 'image' ] }
-                        value={ attributes.bgImage }
+                        value={ image }
                         render={ ( { open } ) => (
                         	<Button onClick={ open } isDefault isLarge>Replace background image</Button>
                         ) }
@@ -120,7 +126,7 @@ export default function Edit( props ) {
                 </MediaUploadCheck>
 				</PanelRow>
                 }
-                { attributes.bgImage &&
+                { image &&
 				<PanelRow>
                 <MediaUploadCheck>
                 	<Button onClick={ onRemoveImage } isLink isDestructive>Remove background image</Button>
@@ -146,13 +152,13 @@ export default function Edit( props ) {
 				</PanelBody>
 			</InspectorControls>,
 			<div { ...blockProps }>
-			{ attributes.bgImage === undefined && (
-		  	<div className={ "strip " + imagePostion.slug + " " + imagePostion.text + " " + attributes.padding + " my-" + attributes.spacing } >
+			{ image === undefined && (
+		  	<div className={ "strip " + attributes.colorSlug + " " + attributes.textColor + " " + attributes.padding + " my-" + attributes.spacing } >
 				<InnerBlocks templateLock={ false } renderAppender={ () => ( <InnerBlocks.DefaultBlockAppender /> ) } />
 			</div>
 			) }
-			{ attributes.bgImage &&
-		  	<div className={ "strip " + attributes.padding + " my-" + attributes.spacing } style={{ backgroundImage: `url(${attributes.bgImage.url})` }}>
+			{ image &&
+		  	<div className={ "strip " + attributes.padding + " my-" + attributes.spacing } style={{ backgroundImage: `url(${attributes.imageUrl})` }}>
 				<InnerBlocks templateLock={ false } renderAppender={ () => ( <InnerBlocks.DefaultBlockAppender /> ) } />
 			</div>
 			}

--- a/src/blocks/strip/save.js
+++ b/src/blocks/strip/save.js
@@ -25,19 +25,17 @@ import { InnerBlocks } from '@wordpress/block-editor';
 export default function save( props ) {
 	const { attributes } = props;
 
-	const { imagePostion } = attributes;
-
 	return (
 		<div className={ attributes.className }>
-			{ attributes.bgImage === undefined && (
-			<div className={ "strip " + imagePostion.slug + " " + imagePostion.text + " " + attributes.padding + " my-" + attributes.spacing } >
+			{ !attributes.imageUrl && (
+			<div className={ "strip " + attributes.colorSlug + " " + attributes.textColor + " " + attributes.padding + " my-" + attributes.spacing } >
 			  <div className="container">
 				<InnerBlocks.Content />
 				</div>
 			</div>
 			) }
-			{ attributes.bgImage && (
-		  	<div className={ "strip " + attributes.padding + " my-" + attributes.spacing } style={{ backgroundImage: `url(${attributes.bgImage.url})` }}>
+			{ attributes.imageUrl && (
+		  	<div className={ "strip " + attributes.padding + " my-" + attributes.spacing } style={{ backgroundImage: `url(${attributes.imageUrl})` }}>
 				<div className="container">
 				<InnerBlocks.Content />
 				</div>


### PR DESCRIPTION
Make some object- and array-type block-attributes GraphQL-friendly:

- "Flatten" object-attributes by replacing them with individual attributes for their properties.
- For the Calendar block, replace the array-attributes with string-attributes, and introduce `encodeURIComponent()`/`decodeURIComponent()` steps to the string/array conversions in `edit.js` (to account for possibility of special characters).